### PR TITLE
Fix building on Ubuntu.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         os:
           - macos-latest
+          - ubuntu-latest
         ocaml-version:
           - 4.08.1
           - 4.11.1

--- a/libmacaroons/config/discover.ml
+++ b/libmacaroons/config/discover.ml
@@ -68,6 +68,6 @@ let () =
       let link_flags = link_flags c in
       C.Flags.write_lines "cflags" lines;
       C.Flags.write_lines "ctypes-cflags" [cstubs_cflags];
-      C.Flags.write_lines "c_library_flags" link_flags;
+      C.Flags.write_sexp "c_library_flags.sexp" link_flags;
       define_constants c;
     )

--- a/libmacaroons/config/discover.ml
+++ b/libmacaroons/config/discover.ml
@@ -69,5 +69,6 @@ let () =
       C.Flags.write_lines "cflags" lines;
       C.Flags.write_lines "ctypes-cflags" [cstubs_cflags];
       C.Flags.write_sexp "c_library_flags.sexp" link_flags;
+      C.Flags.write_lines "c_library_flags" link_flags;
       define_constants c;
     )

--- a/libmacaroons/config/dune
+++ b/libmacaroons/config/dune
@@ -3,5 +3,5 @@
  (libraries dune.configurator))
 
 (rule
- (targets cflags c_library_flags.sexp ctypes-cflags config.h)
+ (targets cflags c_library_flags.sexp c_library_flags ctypes-cflags config.h)
  (action (run ./discover.exe -cstubs %{lib:ctypes:ctypes_cstubs_internals.h})))

--- a/libmacaroons/config/dune
+++ b/libmacaroons/config/dune
@@ -3,5 +3,5 @@
  (libraries dune.configurator))
 
 (rule
- (targets cflags c_library_flags ctypes-cflags config.h)
+ (targets cflags c_library_flags.sexp ctypes-cflags config.h)
  (action (run ./discover.exe -cstubs %{lib:ctypes:ctypes_cstubs_internals.h})))

--- a/libmacaroons/ffi/lib/dune
+++ b/libmacaroons/ffi/lib/dune
@@ -4,6 +4,7 @@
  (modules g m)
  (foreign_stubs (language c) (names macaroons_stubs))
  (foreign_archives ../../vendor/macaroons)
+ (c_library_flags (:include ../../config/c_library_flags.sexp))
  (libraries libmacaroons.bindings libmacaroons.types ctypes.stubs ctypes libmacaroons.c))
 
 (rule

--- a/libmacaroons/vendor/dune
+++ b/libmacaroons/vendor/dune
@@ -6,8 +6,7 @@
 (rule
  (targets libmacaroons%{ext_lib} dllmacaroons%{ext_dll})
  (deps   macaroons.o base64.o slice.o v1.o v2.o packet.o varint.o explicit_bzero.o sha256.o tweetnacl.o port.o timingsafe_bcmp.o)
- (action (run ocamlmklib -o macaroons %{deps})))
-
+ (action (run ocamlmklib %{read-lines:../config/c_library_flags} -o macaroons %{deps})))
 
 (rule
  (targets macaroons.o)

--- a/libmacaroons/vendor/dune
+++ b/libmacaroons/vendor/dune
@@ -5,8 +5,8 @@
 
 (rule
  (targets libmacaroons%{ext_lib} dllmacaroons%{ext_dll})
- (deps   macaroons.o base64.o slice.o v1.o v2.o packet.o varint.o explicit_bzero.o sha256.o tweetnacl.o port.o)
- (action (run ocamlmklib %{read-lines:../config/c_library_flags} -o macaroons %{deps})))
+ (deps   macaroons.o base64.o slice.o v1.o v2.o packet.o varint.o explicit_bzero.o sha256.o tweetnacl.o port.o timingsafe_bcmp.o)
+ (action (run ocamlmklib -o macaroons %{deps})))
 
 
 (rule
@@ -64,5 +64,11 @@
  (targets port.o)
  (deps    (:c port.c) port.h)
  (action  (run %{cc} %{read-lines:../config/cflags} -I. -I../config -c %{c})))
+
+(rule
+ (targets timingsafe_bcmp.o)
+ (deps    (:c timingsafe_bcmp.c))
+ (action  (run %{cc} %{read-lines:../config/cflags} -I. -c %{c})))
+
 
 


### PR DESCRIPTION
Add timingsafe_bcmp to c library build.

Move the linking flags back up to the ffi library level.